### PR TITLE
[Stability] Shut down of LXC sevice (Enable for ENG builds)

### DIFF
--- a/init/Android.bp
+++ b/init/Android.bp
@@ -151,7 +151,7 @@ libinit_cc_defaults {
         eng: {
             cppflags: [
                 "-USHUTDOWN_ZERO_TIMEOUT",
-                "-DSHUTDOWN_ZERO_TIMEOUT=1",
+                "-DSHUTDOWN_ZERO_TIMEOUT=0",
             ],
         },
         uml: {
@@ -416,7 +416,7 @@ cc_binary {
         eng: {
             cflags: [
                 "-USHUTDOWN_ZERO_TIMEOUT",
-                "-DSHUTDOWN_ZERO_TIMEOUT=1",
+                "-DSHUTDOWN_ZERO_TIMEOUT=0",
             ],
         },
     },


### PR DESCRIPTION
Enable eng build variant to undergo graceful shutdown

L4B-Ticket: vcpi-172