### PR TITLE
Introduced flexible min_battery_boot parameter

### DIFF
--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -97,8 +97,6 @@ char* locale;
 #define LOGW(x...) KLOG_WARNING("charger", x);
 #define LOGV(x...) KLOG_DEBUG("charger", x);
 
-#define MIN_BATTERY_FOR_BOOT 10
-
 namespace android {
 
 #if defined(__ANDROID_VNDK__)
@@ -203,7 +201,10 @@ void Charger::InitDefaultAnimationFrames() {
 }
 
 Charger::Charger(ChargerConfigurationInterface* configuration)
-    : batt_anim_(BASE_ANIMATION), configuration_(configuration) {}
+    : batt_anim_(BASE_ANIMATION), configuration_(configuration) {
+    min_battery_for_boot_ = property_get_int32("persist.vendor.softing.min_battery_for_boot", min_battery_for_boot_);
+    LOGW("Taking min_battery_for_boot_ value: %i\n", min_battery_for_boot_);
+}
 
 Charger::~Charger() {}
 
@@ -634,7 +635,7 @@ void Charger::OnHeartbeat() {
      * screen transitions (animations, etc)
      */
     UpdateScreenState(now);
-    if (health_info_.battery_level >= MIN_BATTERY_FOR_BOOT) {
+    if (health_info_.battery_level >= min_battery_for_boot_) {
         LOGW("rebooting\n");
         reboot(RB_AUTOBOOT);
     }

--- a/healthd/include_charger/charger/healthd_mode_charger.h
+++ b/healthd/include_charger/charger/healthd_mode_charger.h
@@ -116,6 +116,7 @@ class Charger {
     int64_t next_key_check_ = 0;
     int64_t next_pwr_check_ = 0;
     int64_t wait_batt_level_timestamp_ = 0;
+    int32_t min_battery_for_boot_{8}; // percentage
 
     DirectRenderManager drm_;
     SrceenSwitch screen_switch_;


### PR DESCRIPTION
Interacts with https://github.com/SoftingAE-VCPI/VCPI.android.device.sony.pdx223/pull/27
https://dev.azure.com/SoftingAutomotiveElectronics/Automotive/_git/VCPI.BMW.VCPI-device/pullrequest/3892

The boot percentage is now configured at 8% fix, or it is set by the file /oem/softing.min_battery_for_boot which will overwrite this value if the property exists.
The reason for this is: If the 8% limit will not be enough, for example when the the battery gets older, we are able to configure this value.
The changed value is a file since a persistent property is not available in charger mode