### PR TITLE
init: don't skip starting a service with no domain if permissive

### DIFF
--- a/init/service.cpp
+++ b/init/service.cpp
@@ -99,13 +99,16 @@ static Result<std::string> ComputeContextFromExecutable(const std::string& servi
         free(new_con);
     }
     if (rc == 0 && computed_context == mycon.get()) {
-        return Error() << "File " << service_path << "(labeled \"" << filecon.get()
-                       << "\") has incorrect label or no domain transition from " << mycon.get()
-                       << " to another SELinux domain defined. Have you configured your "
-                          "service correctly? https://source.android.com/security/selinux/"
-                          "device-policy#label_new_services_and_address_denials. Note: this "
-                          "error shows up even in permissive mode in order to make auditing "
-                          "denials possible.";
+        std::string error = StringPrintf(
+                "File %s (labeled \"%s\") has incorrect label or no domain transition from %s to "
+                "another SELinux domain defined. Have you configured your "
+                "service correctly? https://source.android.com/security/selinux/"
+                "device-policy#label_new_services_and_address_denials",
+                service_path.c_str(), filecon.get(), mycon.get());
+        if (security_getenforce() != 0) {
+            return Error() << error;
+        }
+        LOG(ERROR) << error;
     }
     if (rc < 0) {
         return Error() << "Could not get process context";


### PR DESCRIPTION
[Adrian DC] Preserve the log while permissive

Previously it was a precompiled binary in vendor.img

This is part of a 3 PRs:
https://github.com/SoftingAE-VCPI/VCPI.android.build.buildsupport/pull/50
https://github.com/SoftingAE-VCPI/VCPI.android.device.google.lynx/pull/41

Change-Id: I3f2887930e15d09014c2594141ba4acbbc8d6d9d