### PR TITLE
Add support for showing battery temperature warning in pixel devices

### DIFF
--- a/fs_mgr/fs_mgr_vendor_overlay.cpp
+++ b/fs_mgr/fs_mgr_vendor_overlay.cpp
@@ -110,11 +110,17 @@ bool fs_mgr_vendor_overlay_mount(const std::pair<std::string, std::string>& moun
 bool fs_mgr_vendor_overlay_mount_all() {
     // To read the property, it must be called at the second init stage after the default
     // properties are loaded.
-    static const auto vndk_version = android::base::GetProperty(kVndkVersionPropertyName, "");
+    std::string vndk_version = android::base::GetProperty("ro.vndk.version", "");
+
+    // If VNDK is empty, attempt to fall back to the SDK version
     if (vndk_version.empty()) {
-        // Vendor overlay is disabled from VNDK deprecated devices.
-        LINFO << "vendor overlay: vndk version not defined";
-        return false;
+        vndk_version = android::base::GetProperty("ro.build.version.sdk", "");
+
+        // If both are completely missing, we must abort
+        if (vndk_version.empty()) {
+            LINFO << "vendor overlay: neither vndk version nor sdk version defined";
+            return false;
+        }
     }
 
     const auto vendor_overlay_dirs = fs_mgr_get_vendor_overlay_dirs(vndk_version);

--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -39,6 +39,7 @@
 #include <android-base/file.h>
 #include <android-base/logging.h>
 #include <android-base/macros.h>
+#include <android-base/parseint.h>
 #include <android-base/strings.h>
 
 #include <linux/netlink.h>
@@ -101,8 +102,6 @@ char* locale;
 #define LOGW(x...) KLOG_WARNING("charger", x);
 #define LOGV(x...) KLOG_DEBUG("charger", x);
 
-#define REBOOT_SAFE_TEMPERATURE 450  // 45.0C
-
 inline bool file_exists (const std::string& name) {
   struct stat buffer;
   return (stat (name.c_str(), &buffer) == 0);
@@ -128,9 +127,10 @@ static constexpr const char* system_animation_root = "/system/etc/res/images/";
 // both paths.
 static constexpr const char* product_animation_desc_path =
         "/product/etc/res/values/charger/animation.txt";
-static constexpr const char* product_animation_root = "/product/etc/res/images/";
 static constexpr const char* animation_desc_path = "/res/values/charger/animation.txt";
 #endif
+
+static constexpr const char* product_animation_root = "/product/etc/res/images/";
 
 static const animation BASE_ANIMATION = {
     .text_clock =
@@ -401,7 +401,7 @@ void Charger::UpdateScreenState(int64_t now) {
         }
     }
 
-    if (health_info_.battery_temperature >= REBOOT_SAFE_TEMPERATURE) {
+    if (health_info_.battery_temperature >= boot_safe_temp_) {
         LOGW("device too hot\n");
         batt_anim_.overheat = true;
     }
@@ -601,7 +601,7 @@ void Charger::HandlePowerSupplyState(int64_t now) {
                  now, (int64_t)timer_shutdown, next_pwr_check_);
         } else if (now >= next_pwr_check_) {
             LOGW("[%" PRId64 "] shutting down\n", now);
-            //reboot(RB_POWER_OFF);
+            reboot(RB_POWER_OFF);
         } else {
             /* otherwise we already have a shutdown timer scheduled */
         }
@@ -632,9 +632,20 @@ void Charger::OnHeartbeat() {
     /* do screen update last in case any of the above want to start
      * screen transitions (animations, etc)
      */
+    std::string boot_temp_str = "";
+    if (base::ReadFileToString("/metadata/bootstat/boot.battery_temperature", &boot_temp_str)) {
+        boot_temp_str = android::base::Trim(boot_temp_str);
+        android::base::ParseInt(boot_temp_str, &boot_safe_temp_);
+        LOGW("boot_safe_temp_ from  /metadata/bootstat/boot.battery_temperature is %d" , boot_safe_temp_);
+        std::string err;
+        if (!base::RemoveFileIfExists("/metadata/bootstat/boot.battery_temperature", &err)) {
+            LOGE("Failed to remove /metadata/bootstat/boot.battery_temperature, err=%s", err.c_str());
+        }
+    }
     UpdateScreenState(now);
-    LOGW(" OnHeartbeat : battery level=%i, temperature=%i\n", health_info_.battery_level, health_info_.battery_temperature);
-    if (health_info_.battery_temperature < REBOOT_SAFE_TEMPERATURE) {
+    LOGW(" OnHeartbeat : battery level=%i, boot_safe_temperature=%i, battery_temperature=%i\n", health_info_.battery_level,
+            boot_safe_temp_, health_info_.battery_temperature);
+    if (health_info_.battery_temperature < boot_safe_temp_) {
         LOGW("rebooting\n");
         property_set("sys.powerctl", "reboot,battery-cooldown");
     }
@@ -739,8 +750,8 @@ void Charger::InitAnimation() {
         batt_anim_.fail_file.assign(default_animation_root + "charger/battery_fail.png"s);
     }
 
-    batt_anim_.temp_file.assign(default_animation_root + "charger/high_temp.png"s);
-    batt_anim_.temp_font_file.assign(default_animation_root + "charger/temp_font.png"s);
+    batt_anim_.temp_file.assign(product_animation_root + "charger/high_temp.png"s);
+    batt_anim_.temp_font_file.assign(product_animation_root + "charger/temp_font.png"s);
 
     LOGV("Animation Description:\n");
     LOGV("  animation: %d %d '%s' (%d)\n", batt_anim_.num_cycles, batt_anim_.first_frame_repeats,

--- a/healthd/include_charger/charger/healthd_mode_charger.h
+++ b/healthd/include_charger/charger/healthd_mode_charger.h
@@ -28,6 +28,8 @@
 
 #include "animation.h"
 
+#define REBOOT_SAFE_TEMPERATURE 450  // 45.0C
+
 class GRSurface;
 class HealthdDraw;
 
@@ -134,5 +136,6 @@ class Charger {
     std::vector<animation::frame> owned_frames_;
 
     ChargerConfigurationInterface* configuration_;
+    int boot_safe_temp_ = REBOOT_SAFE_TEMPERATURE;
 };
 }  // namespace android

--- a/init/init.cpp
+++ b/init/init.cpp
@@ -1089,10 +1089,10 @@ int SecondStageMain(int argc, char** argv) {
     am.QueueEventTrigger("init");
 
     // Don't mount filesystems or start core system services in charger mode.
-    std::string bootmode = GetProperty("ro.bootmode", "");
+    std::string bootmode = GetProperty("ro.system.boot.mode", "");
     // Reboot to charger mode only if device was shutdown due to thermal reasons.
     std::string boot_reason = "";
-    if (ReadFileToString(LAST_REBOOT_REASON_FILE, &boot_reason) &&
+    if (bootmode == "charger" && ReadFileToString(LAST_REBOOT_REASON_FILE, &boot_reason) &&
             boot_reason.find("thermal") != std::string::npos) {
         SetProperty("ro.boot.mode", "charger");
         SetProperty("ro.bootmode", "charger");

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -693,15 +693,18 @@ static void handle_property_set_fd(int fd) {
 
 uint32_t InitPropertySet(const std::string& name, const std::string& value) {
     // Skip setting ro.boot.mode property
+    const std::string* target_name = &name;
+    std::string override_name;
     if (name == "ro.boot.mode") {
-        return PROP_SUCCESS;
+        override_name = "ro.system.boot.mode";
+        target_name = &override_name;
     }
 
     ucred cr = {.pid = 1, .uid = 0, .gid = 0};
     std::string error;
-    auto result = HandlePropertySetNoSocket(name, value, kInitContext, cr, &error);
+    auto result = HandlePropertySetNoSocket(*target_name, value, kInitContext, cr, &error);
     if (result != PROP_SUCCESS) {
-        LOG(ERROR) << "Init cannot set '" << name << "' to '" << value << "': " << error;
+        LOG(ERROR) << "Init cannot set '" << *target_name << "' to '" << value << "': " << error;
     }
 
     return result;


### PR DESCRIPTION
    - Move font and high temp image to product as vendor is prebuilt.
    - add support to test the temp warning
        - add a dummy high temp value to /metadata/bootstat/boot.battery_temperature
            - ex. `echo 200 > /metadata/bootstat/boot.battery_temperature && chmod 0666 /metadata/bootstat/boot.battery_temperature`
        - set `setprop ro.shutdown.battery_temperature 200` (lower value that current battery temp to trigger shutdown)
        - Device will show high temp warning as long as power is connected
        - disconnect power and wait 15 seconds, upon connecting power again , device will boot to android