### PR TITLE
Revert "Consider boot mode while booting to charger mode"

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -1089,10 +1089,10 @@ int SecondStageMain(int argc, char** argv) {
     am.QueueEventTrigger("init");
 
     // Don't mount filesystems or start core system services in charger mode.
-    std::string bootmode = GetProperty("ro.system.boot.mode", "");
+    std::string bootmode = GetProperty("ro.bootmode", "");
     // Reboot to charger mode only if device was shutdown due to thermal reasons.
     std::string boot_reason = "";
-    if (bootmode == "charger" && ReadFileToString(LAST_REBOOT_REASON_FILE, &boot_reason) &&
+    if (ReadFileToString(LAST_REBOOT_REASON_FILE, &boot_reason) &&
             boot_reason.find("thermal") != std::string::npos) {
         SetProperty("ro.boot.mode", "charger");
         SetProperty("ro.bootmode", "charger");

--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -693,18 +693,15 @@ static void handle_property_set_fd(int fd) {
 
 uint32_t InitPropertySet(const std::string& name, const std::string& value) {
     // Skip setting ro.boot.mode property
-    const std::string* target_name = &name;
-    std::string override_name;
     if (name == "ro.boot.mode") {
-        override_name = "ro.system.boot.mode";
-        target_name = &override_name;
+        return PROP_SUCCESS;
     }
 
     ucred cr = {.pid = 1, .uid = 0, .gid = 0};
     std::string error;
-    auto result = HandlePropertySetNoSocket(*target_name, value, kInitContext, cr, &error);
+    auto result = HandlePropertySetNoSocket(name, value, kInitContext, cr, &error);
     if (result != PROP_SUCCESS) {
-        LOG(ERROR) << "Init cannot set '" << *target_name << "' to '" << value << "': " << error;
+        LOG(ERROR) << "Init cannot set '" << name << "' to '" << value << "': " << error;
     }
 
     return result;


### PR DESCRIPTION
reason for revert: lynx and akita will not enter charger mode at all if off-mode-charge is disabled with `fastboot oem off-mode-charge 0`

This reverts commit 27614794cfd635e6c0f35f004d0838fe6733afd2.